### PR TITLE
distributed 2022.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2021.10.0" %}
+{% set version = "2022.2.1" %}
 
 package:
   name: distributed
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/d/distributed/distributed-{{ version }}.tar.gz
-  sha256: ea27051fdb8351710978fd1beac49d5b9ad2b919328b4d348f5c58b1393dd84d
+  sha256: fb62a75af8ef33bbe1aa80a68c01a33a93c1cd5a332dd017ab44955bf7ecf65b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,51 +1,45 @@
+{% set name = "distributed" %}
 {% set version = "2022.2.1" %}
 
 package:
-  name: distributed
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/d/distributed/distributed-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: fb62a75af8ef33bbe1aa80a68c01a33a93c1cd5a332dd017ab44955bf7ecf65b
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - dask-scheduler=distributed.cli.dask_scheduler:go
     - dask-ssh=distributed.cli.dask_ssh:go
     - dask-worker=distributed.cli.dask_worker:go
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
-  skip: true  # [py<37]
-  # Python 3.6 is no longer supported https://distributed.dask.org/en/latest/changelog.html
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - python
     - pip
     - wheel
     - setuptools
-
   run:
-    - python
+    - python >=3.8
     - click >=6.6
     - cloudpickle >=1.5.0
-    - cytoolz >=0.8.2
     - dask-core {{ version }}
+    - jinja2
     - msgpack-python >=0.6.0
+    - packaging >=20.0
     - psutil >=5.0
     - pyyaml
+    - setuptools
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
     - toolz >=0.8.2
-    - tornado >=5  # [py<38]
-    - tornado >=6.0.3  # [py>=38]
+    - tornado >=6.0.3
     - zict >=0.1.3
-    - setuptools
-    - jinja2
-    - colorama   #[win]
-
   run_constrained:
     - openssl !=1.1.1e
 
@@ -59,7 +53,6 @@ test:
     - distributed.protocol
   requires:
     - pip
-    - click >=6.6,!=8.0.3   # [py<38]
   commands:
     - pip check
     - dask-scheduler --help
@@ -70,7 +63,7 @@ test:
 #      dask-core --->distributed --->dask
 
 about:
-  home: http://distributed.readthedocs.io/en/latest/
+  home: https://distributed.readthedocs.io/en/latest/
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD


### PR DESCRIPTION
Update distributed to 2022.2.1

License: https://github.com/dask/distributed/blob/2022.02.1/LICENSE.txt
Changelog: https://github.com/dask/distributed/blob/2022.02.1/docs/source/changelog.rst
Requirements: 
- https://github.com/dask/distributed/blob/2022.02.1/setup.py
- https://github.com/dask/distributed/blob/2022.02.1/requirements.txt

Actions: 
1. Make noarch: python
2. Remove skip py<37
3. Remove requirements/build (we don't provide cross-compiling)
4. Use python >=3.8 in run, see https://github.com/dask/distributed/blob/2022.02.1/docs/source/changelog.rst#deprecations
5. Update run dependencies: remove preprocess selectors and `colorama`, add `packaging >=20.0`
6. Remove click from test/requires
7. Fix home url with HTTPS

**Note:** The build and dependency order for dask-distributed packages are as follows.
      `dask-core --->distributed --->dask`