### PR TITLE
update distributed to 2022.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels: 
-  avalon-staging: dask_test
+#channels: 
+#  avalon-staging: dask_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-# channels: 
-#   cbouss: dask_dev 
+channels: 
+  avalon-staging: dask_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - sortedcontainers !=2.0.0,!=2.0.1
     - tblib >=1.6.0
     - toolz >=0.8.2
-    - tornado >=6.0.3
+    - tornado >=6.0.3,<6.2
     - urllib3
     - zict >=0.1.3
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,7 @@
 {% set name = "distributed" %}
-{% set version = "2022.5.0" %}
+{% set version = "2022.7.0" %}
+{% set build_number = "0" %}
+{% set checksum = "e68aba8be3e20e5d1120abcac841909ff18021708a8412afa58ff153c4fab0ac" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +9,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bc8df614fb51c046875478e647c01539f5f41a00abf3d87ef2c6af00932dc509
+  sha256: {{ checksum }}
 
 build:
-  number: 0
+  number: {{ build_number }}
   entry_points:
     - dask-scheduler=distributed.cli.dask_scheduler:main
     - dask-ssh=distributed.cli.dask_ssh:main


### PR DESCRIPTION
Changelog:
- bump version, update checksum
- added `<6.2` to `tornado` constraints per [the upstream requirements](https://github.com/dask/distributed/blame/2022.7.0/requirements.txt#L12)