### PR TITLE
2023.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,3 +88,5 @@ extra:
     - ogrisel
     - tomaugspurger
     - jrbourbeau
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,3 +90,4 @@ extra:
     - jrbourbeau
   skip-lints:
     - python_build_tool_in_run
+    

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "distributed" %}
-{% set version = "2023.5.1" %}
+{% set version = "2023.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: a5c4ffcaabfcf8fd32ef79f6ead17108b248baba25c9e6fb305a9904ad6e5229
+  sha256: a5bdd4d15f3e7c8df98513b409753d46a39827a650620cc0c0c5ef2751561280
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,4 +90,3 @@ extra:
     - jrbourbeau
   skip-lints:
     - python_build_tool_in_run
-    


### PR DESCRIPTION
[Upstream](https://github.com/dask/distributed)
[Changelog](https://distributed.dask.org/en/stable/changelog.html)

### Actions
- Updated version to `2023.6.0`
- Added a linter skip for `python_build_tool_in_run`