### PR TITLE
distributed 2024.5.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr34/176887b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/dask-core-feedstock/pr34/176887b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,10 +59,6 @@ test:
     - dask-scheduler --help
     - dask-ssh --help
     - dask-worker --help
-    - dask scheduler --help
-    - dask ssh --help
-    - dask worker --help
-    - dask spec --help
 
 #Note: The build and dependency order for dask-distributed packages are as follows.
 #      dask-core --->distributed --->dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - python
     - click >=8.0
     - cloudpickle >=1.5.0
-    - dask-core {{ version }}
+    - dask-core =={{ version }}
     - jinja2 >=2.10.3
     - locket >=1.0.0
     - msgpack-python >=1.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "distributed" %}
-{% set version = "2023.11.0" %}
+{% set version = "2024.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,16 +7,16 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 6a5ab490bd966d83a04210d560ed72fbb0518e88d63b3a176b6370b296cbd8d5
+  sha256: 0f83d627551d3748a5478cd03e12e905dbd620a1adcfab0a0d6a488fd6561b48
 
 build:
   number: 0
+  skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv --no-build-isolation
   entry_points:
     - dask-scheduler=distributed.cli.dask_scheduler:main
     - dask-ssh=distributed.cli.dask_ssh:main
     - dask-worker=distributed.cli.dask_worker:main
-  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vv --no-build-isolation
-  skip: true  # [py<39]
 
 requirements:
   host:
@@ -24,7 +24,7 @@ requirements:
     - pip
     - wheel
     - setuptools
-    - versioneer
+    - versioneer 0.29
     - tomli
   run:
     - python
@@ -59,6 +59,10 @@ test:
     - dask-scheduler --help
     - dask-ssh --help
     - dask-worker --help
+    - dask scheduler --help
+    - dask ssh --help
+    - dask worker --help
+    - dask spec --help
 
 #Note: The build and dependency order for dask-distributed packages are as follows.
 #      dask-core --->distributed --->dask
@@ -68,7 +72,7 @@ about:
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD
-  summary: Distributed computing with Dask
+  summary: A distributed task scheduler for Dask
   description: |
     Distributed is a lightweight library for distributed computing in Python.
     It extends both the concurrent.futures and dask APIs to moderate sized


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4809](https://anaconda.atlassian.net/browse/PKG-4809)
- releases: https://github.com/dask/distributed/tags
- release-diff: https://github.com/dask/distributed/compare/2023.11.0...2024.5.0
- license: https://github.com/dask/distributed/blob/main/LICENSE.txt
- requirements-tagged: https://github.com/dask/distributed/blob/2024.5.0/pyproject.toml


### Explanation of changes:

- Pin `versioneer` to `0.29`
- Use **=={{ version }}** for `dask-core` to get at runtime `dask-core 2024.5.0` instead of `dask-core 2024.5.0.*`
- Update summary


### Notes:

- The build and dependency order for dask-distributed packages are as follows:
  -   dask-core -> distributed -> dask



[PKG-4809]: https://anaconda.atlassian.net/browse/PKG-4809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ