### PR TITLE
distributed 2026.7.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,15 @@
 {% set name = "distributed" %}
-{% set version = "2026.6.0" %}
+{% set version = "2026.7.0" %}
 
+# Note: The build and dependency order for dask-distributed packages are as follows.
+# dask-core -> dask-expr -> distributed -> dask
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 88b836dc2d85340cad7e08f2611b9336a70ed018d88bc5a70c3721d4a7efcabd
+  sha256: 3b9ecc6c9d1a9ad64e6b5ba6ec3e35c28efcda6f04fa105074179ad79f45c8b9
 
 build:
   number: 0
@@ -29,7 +31,7 @@ requirements:
     - python
     - click >=8.0
     - cloudpickle >=3.0.0
-    - dask-core =={{ version }}
+    - dask-core >=2026.7.0,<2026.7.1
     - jinja2 >=2.10.3
     - locket >=1.0.0
     - msgpack-python >=1.0.2
@@ -111,8 +113,6 @@ test:
     - dask-worker --help
     - dask-spec --help
 
-# Note: The build and dependency order for dask-distributed packages are as follows.
-# dask-core -> dask-expr -> distributed -> dask
 about:
   home: https://distributed.dask.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,6 +110,8 @@ test:
     - dask-worker --help
     - dask-spec --help
 
+# Note: The build and dependency order for dask-distributed packages are as follows.
+# dask-core -> dask-expr -> distributed -> dask
 about:
   home: https://distributed.dask.org
   license: BSD-3-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,13 @@
 {% set name = "distributed" %}
-{% set version = "2026.7.0" %}
+{% set version = "2026.7.1" %}
 
-# Note: The build and dependency order for dask-distributed packages are as follows.
-# dask-core -> dask-expr -> distributed -> dask
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3b9ecc6c9d1a9ad64e6b5ba6ec3e35c28efcda6f04fa105074179ad79f45c8b9
+  sha256: f7c48ab6961734874521574d75898466703bce93f22f0cff5872c7e4ac6425d4
 
 build:
   number: 0
@@ -31,7 +29,7 @@ requirements:
     - python
     - click >=8.0
     - cloudpickle >=3.0.0
-    - dask-core >=2026.7.0,<2026.7.1
+    - dask-core =={{ version }}
     - jinja2 >=2.10.3
     - locket >=1.0.0
     - msgpack-python >=1.0.2
@@ -42,7 +40,6 @@ requirements:
     - tblib >=1.6.0,!=3.2.0,!=3.2.1
     - toolz >=0.12.0
     - tornado >=6.2.0
-    - urllib3 >=1.26.5
     - zict >=3.0.0
 
 test:


### PR DESCRIPTION
## Bump distributed to 2026.7.1

### Links
- [PKG-16230](https://anaconda.atlassian.net/browse/PKG-16230) — distributed 2026.7.1
- [distributed dev](https://github.com/dask/distributed)
- [conda-forge recipe](https://github.com/conda-forge/distributed-feedstock)
- [PyPI](https://pypi.org/project/distributed/2026.7.1/)
- [PyPI Inspector](https://inspector.pypi.io/project/distributed/2026.7.1/)

### Changes
- `recipe/meta.yaml`: bump version 2026.6.0 → 2026.7.1, update sha256, remove stale `urllib3 >=1.26.5` run dependency (unused — not declared in `pyproject.toml`, not imported anywhere in source, also dropped by conda-forge)

### Notes
- **Blocked on `dask`/`dask-core` 2026.7.1**: this recipe pins `dask-core =={{ version }}` (exact match), but `main` currently only has `dask-core 2026.6.0`. Needs a companion PKG ticket for the `dask`/`dask-core` bump before this can build/merge.
- Upstream 2026.7.1 (via 2026.7.0) includes one breaking change in `scatter()` behavior for custom containers (dask/distributed#9298) — requires rebuild of `dask` and retest of 5 downstream packages (dask-glm, dask-jobqueue, dask-ml, modin-dask, unidist-dask) per PBC triage recommendation.

[PKG-16230]: https://anaconda.atlassian.net/browse/PKG-16230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ